### PR TITLE
Fix incorrect material names in default craft files

### DIFF
--- a/modules/Movecraft/src/main/resources/types/1_14/BigAirship.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/BigAirship.craft
@@ -55,20 +55,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/1_14/BigSubAirship.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/BigSubAirship.craft
@@ -55,20 +55,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/1_14/Ship.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/Ship.craft
@@ -54,20 +54,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/1_14/SubAirship.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/SubAirship.craft
@@ -54,20 +54,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/1_14/Submarine.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/Submarine.craft
@@ -54,20 +54,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR
@@ -103,7 +103,7 @@ passthroughBlocks:
     - seagrass
     - bubble_column
 flyblocks:
-    [ACACIA_PLANKS, BIRCH_PLANKS, DARK_OAK_PLANKS, JUNGLE_PLANKS, OAK_PLANKS, SPRUCE_PLANKS]:
+    all_planks:
         - 25.0
         - 100.0
     ANVIL: # anvils are OP armor, so limit it

--- a/modules/Movecraft/src/main/resources/types/1_14/Turret.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/Turret.craft
@@ -37,27 +37,27 @@ allowedBlocks:
         - netherrack
         - glowstone
         - cake
-        - redstone_repeater
+        - repeater
         - all_stained_glass
         - all_trapdoor
         - all_stone_bricks
         - iron_bars
         - glass_pane
         - all_fence_gate
-        - enchantment_table
+        - enchanting_table
         - brewing_stand
         - cauldron
         - dragon_egg
         - redstone_lamp
-        - ender chest
+        - ender_chest
         - TRIPWIRE_HOOK
         - EMERALD_BLOCK
         - BEACON
         - FLOWER_POT
-        - SKULL
+        - all_skull
         - all_ANVIL
         - TRAPPED_CHEST
-        - REDSTONE_COMPARATOR
+        - comparator
         - daylight_detector
         - REDSTONE_BLOCK
         - HOPPER

--- a/modules/Movecraft/src/main/resources/types/1_14/airship.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/airship.craft
@@ -46,7 +46,7 @@ allowedBlocks:
         - netherrack
         - glowstone
         - cake
-        - redstone_repeater
+        - repeater
         - all_stained_glass
         - all_trapdoor
         - all_stone_bricks
@@ -54,23 +54,23 @@ allowedBlocks:
         - glass_pane
         - all_fence_gate
         - nether_brick
-        - enchantment_table
+        - enchanting_table
         - brewing_stand
         - cauldron
         - end_stone
         - dragon_egg
         - redstone_lamp
-        - ender chest
+        - ender_chest
         - TRIPWIRE_HOOK
         - EMERALD_BLOCK
         - BEACON
         - cobblestone_wall
         - mossy_cobblestone_wall
         - FLOWER_POT
-        - SKULL
+        - all_skull
         - all_ANVIL
         - TRAPPED_CHEST
-        - REDSTONE_COMPARATOR
+        - comparator
         - daylight_detector
         - REDSTONE_BLOCK
         - HOPPER

--- a/modules/Movecraft/src/main/resources/types/1_14/airskiff.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/airskiff.craft
@@ -45,17 +45,17 @@ allowedBlocks:
         - iron_bars
         - glass_pane
         - all_fence_gate
-        - enchantment_table
+        - enchanting_table
         - brewing_stand
         - cauldron
         - dragon_egg
         - redstone_lamp
-        - ender chest
+        - ender_chest
         - TRIPWIRE_HOOK
         - EMERALD_BLOCK
         - BEACON
         - FLOWER_POT
-        - SKULL
+        - all_skull
         - all_ANVIL
         - TRAPPED_CHEST
         - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/1_14/elevator.craft
+++ b/modules/Movecraft/src/main/resources/types/1_14/elevator.craft
@@ -45,17 +45,17 @@ allowedBlocks:
         - iron_bars
         - glass_pane
         - all_fence_gate
-        - enchantment_table
+        - enchanting_table
         - brewing_stand
         - cauldron
         - dragon_egg
         - redstone_lamp
-        - ender chest
+        - ender_chest
         - TRIPWIRE_HOOK
         - EMERALD_BLOCK
         - BEACON
         - FLOWER_POT
-        - SKULL
+        - all_skull
         - all_ANVIL
         - TRAPPED_CHEST
         - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/BigAirship.craft
+++ b/modules/Movecraft/src/main/resources/types/BigAirship.craft
@@ -55,20 +55,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/BigSubAirship.craft
+++ b/modules/Movecraft/src/main/resources/types/BigSubAirship.craft
@@ -55,20 +55,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/Ship.craft
+++ b/modules/Movecraft/src/main/resources/types/Ship.craft
@@ -55,20 +55,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/SubAirship.craft
+++ b/modules/Movecraft/src/main/resources/types/SubAirship.craft
@@ -55,20 +55,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/Submarine.craft
+++ b/modules/Movecraft/src/main/resources/types/Submarine.craft
@@ -55,20 +55,20 @@ allowedBlocks:
    - glass_pane
    - all_fence_gate
    - nether_brick
-   - enchantment_table
+   - enchanting_table
    - brewing_stand
    - cauldron
    - end_stone
    - dragon_egg
    - redstone_lamp
-   - ender chest
+   - ender_chest
    - TRIPWIRE_HOOK
    - EMERALD_BLOCK
    - BEACON
    - cobblestone_wall
    - mossy_cobblestone_wall
    - FLOWER_POT
-   - SKULL
+   - all_skull
    - all_ANVIL
    - TRAPPED_CHEST
    - COMPARATOR
@@ -104,7 +104,7 @@ passthroughBlocks:
     - seagrass
     - bubble_column
 flyblocks:
-    [ACACIA_PLANKS, BIRCH_PLANKS, DARK_OAK_PLANKS, JUNGLE_PLANKS, OAK_PLANKS, SPRUCE_PLANKS]:
+    all_planks:
         - 25.0
         - 100.0
     ANVIL: # anvils are OP armor, so limit it

--- a/modules/Movecraft/src/main/resources/types/Turret.craft
+++ b/modules/Movecraft/src/main/resources/types/Turret.craft
@@ -37,27 +37,27 @@ allowedBlocks:
         - netherrack
         - glowstone
         - cake
-        - redstone_repeater
+        - repeater
         - all_stained_glass
         - all_trapdoor
         - all_stone_bricks
         - iron_bars
         - glass_pane
         - all_fence_gate
-        - enchantment_table
+        - enchanting_table
         - brewing_stand
         - cauldron
         - dragon_egg
         - redstone_lamp
-        - ender chest
+        - ender_chest
         - TRIPWIRE_HOOK
         - EMERALD_BLOCK
         - BEACON
         - FLOWER_POT
-        - SKULL
+        - all_skull
         - all_ANVIL
         - TRAPPED_CHEST
-        - REDSTONE_COMPARATOR
+        - comparator
         - daylight_detector
         - REDSTONE_BLOCK
         - HOPPER

--- a/modules/Movecraft/src/main/resources/types/airship.craft
+++ b/modules/Movecraft/src/main/resources/types/airship.craft
@@ -46,7 +46,7 @@ allowedBlocks:
         - netherrack
         - glowstone
         - cake
-        - redstone_repeater
+        - repeater
         - all_stained_glass
         - all_trapdoor
         - all_stone_bricks
@@ -54,23 +54,23 @@ allowedBlocks:
         - glass_pane
         - all_fence_gate
         - nether_brick
-        - enchantment_table
+        - enchanting_table
         - brewing_stand
         - cauldron
         - end_stone
         - dragon_egg
         - redstone_lamp
-        - ender chest
+        - ender_chest
         - TRIPWIRE_HOOK
         - EMERALD_BLOCK
         - BEACON
         - cobblestone_wall
         - mossy_cobblestone_wall
         - FLOWER_POT
-        - SKULL
+        - all_skull
         - all_ANVIL
         - TRAPPED_CHEST
-        - REDSTONE_COMPARATOR
+        - comparator
         - daylight_detector
         - REDSTONE_BLOCK
         - HOPPER

--- a/modules/Movecraft/src/main/resources/types/airskiff.craft
+++ b/modules/Movecraft/src/main/resources/types/airskiff.craft
@@ -45,17 +45,17 @@ allowedBlocks:
         - iron_bars
         - glass_pane
         - all_fence_gate
-        - enchantment_table
+        - enchanting_table
         - brewing_stand
         - cauldron
         - dragon_egg
         - redstone_lamp
-        - ender chest
+        - ender_chest
         - TRIPWIRE_HOOK
         - EMERALD_BLOCK
         - BEACON
         - FLOWER_POT
-        - SKULL
+        - all_skull
         - all_ANVIL
         - TRAPPED_CHEST
         - COMPARATOR

--- a/modules/Movecraft/src/main/resources/types/elevator.craft
+++ b/modules/Movecraft/src/main/resources/types/elevator.craft
@@ -45,17 +45,17 @@ allowedBlocks:
         - iron_bars
         - glass_pane
         - all_fence_gate
-        - enchantment_table
+        - enchanting_table
         - brewing_stand
         - cauldron
         - dragon_egg
         - redstone_lamp
-        - ender chest
+        - ender_chest
         - TRIPWIRE_HOOK
         - EMERALD_BLOCK
         - BEACON
         - FLOWER_POT
-        - SKULL
+        - all_skull
         - all_ANVIL
         - TRAPPED_CHEST
         - COMPARATOR


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Modifies default craft files for 1.13+ with invalid/outdated material names causing errors on load

### Checklist
- [x] Proper internationalization
- [x] Compiled/tested
