### PR TITLE
Improve CI performance and fix readme badge

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -99,9 +99,7 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Stage jar
-      run: mkdir staging && cp target/Movecraft.jar staging
-    - name: Rename jar
-      run: mv staging/Movecraft.jar staging/Movecraft_$GITHUB_SHA.jar
+      run: mkdir staging && cp target/Movecraft.jar staging && mv staging/Movecraft.jar staging/Movecraft_$GITHUB_SHA.jar
     - name: Upload jar
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,45 +17,81 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-m2
         restore-keys: ${{ runner.os }}-m2
 
 # Run Spigot BuildTools for NMS if required
     - name: Setup BuildTools
       if: steps.cache.outputs.cache-hit != 'true'
-      run: mkdir BuildTools
-    - name: Download BuildTools
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+      run: mkdir BuildTools && wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+
+# EXAMPLE - Copy/paste as required to add version support to CI
+#    - name: Test [version]
+#      id: [version name]
+#      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/[NMS version]/craftbukkit-[NMS version].jar && echo "::set-output name=sucess::true"
+#    - name: [version]
+#      if: steps.frostburn.outputs.sucess != 'true'
+#      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
+
+    - name: Test 1.8.8
+      id: bountiful
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.8.8-R0.1-SNAPSHOT/craftbukkit-1.8.8-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.8.8
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.bountiful.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.8.8
+    - name: Test 1.9.4
+      id: combat
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.9.4-R0.1-SNAPSHOT/craftbukkit-1.9.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.9.4
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.combat.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.9.4
+    - name: Test 1.10.2
+      id: frostburn
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.10.2-R0.1-SNAPSHOT/craftbukkit-1.10.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.10.2
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.frostburn.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.10.2
+    - name: Test 1.11.2
+      id: exploration
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.11.2-R0.1-SNAPSHOT/craftbukkit-1.11.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.11.2
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.exploration.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.11.2
+    - name: Test 1.12.1
+      id: color
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.12.1-R0.1-SNAPSHOT/craftbukkit-1.12.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.12.1
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.color.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.12.1
+    - name: Test 1.13.2
+      id: aquatic
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.13.2-R0.1-SNAPSHOT/craftbukkit-1.13.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.13.2
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.aquatic.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.13.2
+    - name: Test 1.14.4
+      id: pillage
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.14.4-R0.1-SNAPSHOT/craftbukkit-1.14.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.14.4
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.pillage.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.14.4 --compile craftbukkit
+    - name: Test 1.15.0
+      id: bees
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.15.0
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.bees.outputs.sucess != 'true''
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.15 --compile craftbukkit
+    - name: Test 1.16.1
+      id: nether
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.16.1
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.nether.outputs.sucess != 'true''
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.1 --compile craftbukkit
+    - name: Test 1.16.3
+      id: nether2
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.16.3
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.nether2.outputs.sucess != 'true''
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.2 --compile craftbukkit
 
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,6 @@ jobs:
 
 # Run Spigot BuildTools for NMS if required
     - name: Setup BuildTools
-      if: steps.cache.outputs.cache-hit != 'true'
       run: mkdir BuildTools && wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
 
 # EXAMPLE - Copy/paste as required to add version support to CI

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
 # EXAMPLE - Copy/paste as required to add version support to CI
 #    - name: Test [version]
 #      id: [version name]
-#      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/[NMS version]/craftbukkit-[NMS version].jar || echo "Failed to find [version]" && echo "::set-output name=sucess::true"
+#      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/[NMS version]/craftbukkit-[NMS version].jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
 #    - name: [version]
 #      if: steps.frostburn.outputs.sucess != 'true'
 #      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
@@ -42,55 +42,55 @@ jobs:
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.8.8
     - name: Test 1.9.4
       id: combat
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.9.4-R0.1-SNAPSHOT/craftbukkit-1.9.4-R0.1-SNAPSHOT.jar || echo "Failed to find 1.9.4" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.9.4-R0.1-SNAPSHOT/craftbukkit-1.9.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.9.4
       if: steps.combat.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.9.4
     - name: Test 1.10.2
       id: frostburn
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.10.2-R0.1-SNAPSHOT/craftbukkit-1.10.2-R0.1-SNAPSHOT.jar || echo "Failed to find 1.10.2" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.10.2-R0.1-SNAPSHOT/craftbukkit-1.10.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.10.2
       if: steps.frostburn.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.10.2
     - name: Test 1.11.2
       id: exploration
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.11.2-R0.1-SNAPSHOT/craftbukkit-1.11.2-R0.1-SNAPSHOT.jar || echo "Failed to find 1.11.2" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.11.2-R0.1-SNAPSHOT/craftbukkit-1.11.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.11.2
       if: steps.exploration.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.11.2
     - name: Test 1.12.1
       id: color
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.12.1-R0.1-SNAPSHOT/craftbukkit-1.12.1-R0.1-SNAPSHOT.jar || echo "Failed to find 1.12.1" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.12.1-R0.1-SNAPSHOT/craftbukkit-1.12.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.12.1
       if: steps.color.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.12.1
     - name: Test 1.13.2
       id: aquatic
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.13.2-R0.1-SNAPSHOT/craftbukkit-1.13.2-R0.1-SNAPSHOT.jar || echo "Failed to find 1.13.2" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.13.2-R0.1-SNAPSHOT/craftbukkit-1.13.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.13.2
       if: steps.aquatic.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.13.2
     - name: Test 1.14.4
       id: pillage
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.14.4-R0.1-SNAPSHOT/craftbukkit-1.14.4-R0.1-SNAPSHOT.jar || echo "Failed to find 1.14.4" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.14.4-R0.1-SNAPSHOT/craftbukkit-1.14.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.14.4
       if: steps.pillage.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.14.4 --compile craftbukkit
     - name: Test 1.15.0
       id: bees
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar || echo "Failed to find 1.15.0" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.15.0
       if: steps.bees.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.15 --compile craftbukkit
     - name: Test 1.16.1
       id: nether
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar || echo "Failed to find 1.16.1" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.16.1
       if: steps.nether.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.1 --compile craftbukkit
     - name: Test 1.16.3
       id: nether2
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar || echo "Failed to find 1.16.3" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.16.3
       if: steps.nether2.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.3 --compile craftbukkit

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,45 +17,82 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-m2
         restore-keys: ${{ runner.os }}-m2
 
 # Run Spigot BuildTools for NMS if required
     - name: Setup BuildTools
       if: steps.cache.outputs.cache-hit != 'true'
-      run: mkdir BuildTools
-    - name: Download BuildTools
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+      run: mkdir BuildTools && wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+
+# EXAMPLE - Copy/paste as required to add version support to CI
+#    - name: Test [version]
+#      id: [version name]
+#      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/[NMS version]/craftbukkit-[NMS version].jar && echo "::set-output name=sucess::true"
+#    - name: [version]
+#      if: steps.frostburn.outputs.sucess != 'true'
+#      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
+    - run: ls ~/.m2/repository/org/bukkit/craftbukkit/
+
+    - name: Test 1.8.8
+      id: bountiful
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.8.8-R0.1-SNAPSHOT/craftbukkit-1.8.8-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.8.8
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.bountiful.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.8.8
+    - name: Test 1.9.4
+      id: combat
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.9.4-R0.1-SNAPSHOT/craftbukkit-1.9.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.9.4
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.combat.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.9.4
+    - name: Test 1.10.2
+      id: frostburn
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.10.2-R0.1-SNAPSHOT/craftbukkit-1.10.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.10.2
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.frostburn.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.10.2
+    - name: Test 1.11.2
+      id: exploration
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.11.2-R0.1-SNAPSHOT/craftbukkit-1.11.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.11.2
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.exploration.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.11.2
+    - name: Test 1.12.1
+      id: color
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.12.1-R0.1-SNAPSHOT/craftbukkit-1.12.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.12.1
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.color.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.12.1
+    - name: Test 1.13.2
+      id: aquatic
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.13.2-R0.1-SNAPSHOT/craftbukkit-1.13.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.13.2
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.aquatic.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.13.2
+    - name: Test 1.14.4
+      id: pillage
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.14.4-R0.1-SNAPSHOT/craftbukkit-1.14.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.14.4
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.pillage.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.14.4 --compile craftbukkit
+    - name: Test 1.15.0
+      id: bees
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.15.0
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.bees.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.15 --compile craftbukkit
+    - name: Test 1.16.1
+      id: nether
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.16.1
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.nether.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.1 --compile craftbukkit
+    - name: Test 1.16.3
+      id: nether2
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.16.3
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.nether2.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.2 --compile craftbukkit
 
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
 # EXAMPLE - Copy/paste as required to add version support to CI
 #    - name: Test [version]
 #      id: [version name]
-#      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/[NMS version]/craftbukkit-[NMS version].jar && echo "::set-output name=sucess::true"
+#      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/[NMS version]/craftbukkit-[NMS version].jar || echo "Failed to find [version]" && echo "::set-output name=sucess::true"
 #    - name: [version]
 #      if: steps.frostburn.outputs.sucess != 'true'
 #      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
@@ -36,64 +36,64 @@ jobs:
 
     - name: Test 1.8.8
       id: bountiful
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.8.8-R0.1-SNAPSHOT/craftbukkit-1.8.8-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.8.8-R0.1-SNAPSHOT/craftbukkit-1.8.8-R0.1-SNAPSHOT.jar || echo "Failed to find 1.8.8" && echo "::set-output name=sucess::true"
     - name: 1.8.8
       if: steps.bountiful.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.8.8
     - name: Test 1.9.4
       id: combat
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.9.4-R0.1-SNAPSHOT/craftbukkit-1.9.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.9.4-R0.1-SNAPSHOT/craftbukkit-1.9.4-R0.1-SNAPSHOT.jar || echo "Failed to find 1.9.4" && echo "::set-output name=sucess::true"
     - name: 1.9.4
       if: steps.combat.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.9.4
     - name: Test 1.10.2
       id: frostburn
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.10.2-R0.1-SNAPSHOT/craftbukkit-1.10.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.10.2-R0.1-SNAPSHOT/craftbukkit-1.10.2-R0.1-SNAPSHOT.jar || echo "Failed to find 1.10.2" && echo "::set-output name=sucess::true"
     - name: 1.10.2
       if: steps.frostburn.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.10.2
     - name: Test 1.11.2
       id: exploration
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.11.2-R0.1-SNAPSHOT/craftbukkit-1.11.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.11.2-R0.1-SNAPSHOT/craftbukkit-1.11.2-R0.1-SNAPSHOT.jar || echo "Failed to find 1.11.2" && echo "::set-output name=sucess::true"
     - name: 1.11.2
       if: steps.exploration.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.11.2
     - name: Test 1.12.1
       id: color
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.12.1-R0.1-SNAPSHOT/craftbukkit-1.12.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.12.1-R0.1-SNAPSHOT/craftbukkit-1.12.1-R0.1-SNAPSHOT.jar || echo "Failed to find 1.12.1" && echo "::set-output name=sucess::true"
     - name: 1.12.1
       if: steps.color.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.12.1
     - name: Test 1.13.2
       id: aquatic
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.13.2-R0.1-SNAPSHOT/craftbukkit-1.13.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.13.2-R0.1-SNAPSHOT/craftbukkit-1.13.2-R0.1-SNAPSHOT.jar || echo "Failed to find 1.13.2" && echo "::set-output name=sucess::true"
     - name: 1.13.2
       if: steps.aquatic.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.13.2
     - name: Test 1.14.4
       id: pillage
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.14.4-R0.1-SNAPSHOT/craftbukkit-1.14.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.14.4-R0.1-SNAPSHOT/craftbukkit-1.14.4-R0.1-SNAPSHOT.jar || echo "Failed to find 1.14.4" && echo "::set-output name=sucess::true"
     - name: 1.14.4
       if: steps.pillage.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.14.4 --compile craftbukkit
     - name: Test 1.15.0
       id: bees
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar || echo "Failed to find 1.15.0" && echo "::set-output name=sucess::true"
     - name: 1.15.0
       if: steps.bees.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.15 --compile craftbukkit
     - name: Test 1.16.1
       id: nether
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar || echo "Failed to find 1.16.1" && echo "::set-output name=sucess::true"
     - name: 1.16.1
       if: steps.nether.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.1 --compile craftbukkit
     - name: Test 1.16.3
       id: nether2
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar || echo "Failed to find 1.16.3" && echo "::set-output name=sucess::true"
     - name: 1.16.3
       if: steps.nether2.outputs.sucess != 'true'
-      run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.2 --compile craftbukkit
+      run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.3 --compile craftbukkit
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,6 +32,7 @@ jobs:
 #    - name: [version]
 #      if: steps.frostburn.outputs.sucess != 'true'
 #      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
+    - run: ls ~/.m2/repository/org/bukkit/craftbukkit/
 
     - name: Test 1.8.8
       id: bountiful

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,64 +34,64 @@ jobs:
 #      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
 #    - run: test -d ~/.m2/repository/org/bukkit/craftbukkit/ && ls ~/.m2/repository/org/bukkit/craftbukkit/
 
-    - name: Test 1.8.8
+    - name: Check 1.8.8
       id: bountiful
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.8.8-R0.1-SNAPSHOT/craftbukkit-1.8.8-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.8.8
+    - name: Build 1.8.8
       if: steps.bountiful.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.8.8
-    - name: Test 1.9.4
+    - name: Check 1.9.4
       id: combat
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.9.4-R0.1-SNAPSHOT/craftbukkit-1.9.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.9.4
+    - name: Build 1.9.4
       if: steps.combat.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.9.4
-    - name: Test 1.10.2
+    - name: Check 1.10.2
       id: frostburn
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.10.2-R0.1-SNAPSHOT/craftbukkit-1.10.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.10.2
+    - name: Build 1.10.2
       if: steps.frostburn.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.10.2
-    - name: Test 1.11.2
+    - name: Check 1.11.2
       id: exploration
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.11.2-R0.1-SNAPSHOT/craftbukkit-1.11.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.11.2
+    - name: Build 1.11.2
       if: steps.exploration.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.11.2
-    - name: Test 1.12.1
+    - name: Check 1.12.1
       id: color
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.12.1-R0.1-SNAPSHOT/craftbukkit-1.12.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.12.1
+    - name: Build 1.12.1
       if: steps.color.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.12.1
-    - name: Test 1.13.2
+    - name: Check 1.13.2
       id: aquatic
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.13.2-R0.1-SNAPSHOT/craftbukkit-1.13.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.13.2
+    - name: Build 1.13.2
       if: steps.aquatic.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.13.2
-    - name: Test 1.14.4
+    - name: Check 1.14.4
       id: pillage
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.14.4-R0.1-SNAPSHOT/craftbukkit-1.14.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.14.4
+    - name: Build 1.14.4
       if: steps.pillage.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.14.4 --compile craftbukkit
-    - name: Test 1.15.0
+    - name: Check 1.15
       id: bees
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.15.0
+    - name: Build 1.15
       if: steps.bees.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.15 --compile craftbukkit
-    - name: Test 1.16.1
+    - name: Check 1.16.1
       id: nether
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.16.1
+    - name: Build 1.16.1
       if: steps.nether.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.1 --compile craftbukkit
-    - name: Test 1.16.3
+    - name: Check 1.16.2
       id: nether2
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.2-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
-    - name: 1.16.3
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.2-R0.1-SNAPSHOT/craftbukkit-1.16.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
+    - name: Build 1.16.2
       if: steps.nether2.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.2 --compile craftbukkit
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ jobs:
 #    - name: [version]
 #      if: steps.frostburn.outputs.sucess != 'true'
 #      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
-    - run: test -d ~/.m2/repository/org/bukkit/craftbukkit/ && ls ~/.m2/repository/org/bukkit/craftbukkit/
+#    - run: test -d ~/.m2/repository/org/bukkit/craftbukkit/ && ls ~/.m2/repository/org/bukkit/craftbukkit/
 
     - name: Test 1.8.8
       id: bountiful

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -90,10 +90,10 @@ jobs:
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.1 --compile craftbukkit
     - name: Test 1.16.3
       id: nether2
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.2-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.16.3
       if: steps.nether2.outputs.sucess != 'true'
-      run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.3 --compile craftbukkit
+      run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.2 --compile craftbukkit
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -79,7 +79,7 @@ jobs:
       id: bees
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.15.0
-      if: steps.bees.outputs.sucess != 'true''
+      if: steps.bees.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.15 --compile craftbukkit
     - name: Test 1.16.1
       id: nether

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Test 1.8.8
       id: bountiful
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.8.8-R0.1-SNAPSHOT/craftbukkit-1.8.8-R0.1-SNAPSHOT.jar || echo "Failed to find 1.8.8" && echo "::set-output name=sucess::true"
+      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.8.8-R0.1-SNAPSHOT/craftbukkit-1.8.8-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true" || echo "::set-output name=sucess::false"
     - name: 1.8.8
       if: steps.bountiful.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.8.8

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,82 +17,45 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.m2
-        key: ${{ runner.os }}-m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
 # Run Spigot BuildTools for NMS if required
     - name: Setup BuildTools
       if: steps.cache.outputs.cache-hit != 'true'
-      run: mkdir BuildTools && wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-
-# EXAMPLE - Copy/paste as required to add version support to CI
-#    - name: Test [version]
-#      id: [version name]
-#      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/[NMS version]/craftbukkit-[NMS version].jar && echo "::set-output name=sucess::true"
-#    - name: [version]
-#      if: steps.frostburn.outputs.sucess != 'true'
-#      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
-    - run: ls ~/.m2/repository/org/bukkit/craftbukkit/
-
-    - name: Test 1.8.8
-      id: bountiful
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.8.8-R0.1-SNAPSHOT/craftbukkit-1.8.8-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
+      run: mkdir BuildTools
+    - name: Download BuildTools
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: wget -O BuildTools/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
     - name: 1.8.8
-      if: steps.bountiful.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.8.8
-    - name: Test 1.9.4
-      id: combat
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.9.4-R0.1-SNAPSHOT/craftbukkit-1.9.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.9.4
-      if: steps.combat.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.9.4
-    - name: Test 1.10.2
-      id: frostburn
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.10.2-R0.1-SNAPSHOT/craftbukkit-1.10.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.10.2
-      if: steps.frostburn.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.10.2
-    - name: Test 1.11.2
-      id: exploration
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.11.2-R0.1-SNAPSHOT/craftbukkit-1.11.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.11.2
-      if: steps.exploration.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.11.2
-    - name: Test 1.12.1
-      id: color
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.12.1-R0.1-SNAPSHOT/craftbukkit-1.12.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.12.1
-      if: steps.color.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.12.1
-    - name: Test 1.13.2
-      id: aquatic
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.13.2-R0.1-SNAPSHOT/craftbukkit-1.13.2-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.13.2
-      if: steps.aquatic.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.13.2
-    - name: Test 1.14.4
-      id: pillage
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.14.4-R0.1-SNAPSHOT/craftbukkit-1.14.4-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.14.4
-      if: steps.pillage.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.14.4 --compile craftbukkit
-    - name: Test 1.15.0
-      id: bees
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.15-R0.1-SNAPSHOT/craftbukkit-1.15-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.15.0
-      if: steps.bees.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.15 --compile craftbukkit
-    - name: Test 1.16.1
-      id: nether
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.16.1
-      if: steps.nether.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.1 --compile craftbukkit
-    - name: Test 1.16.3
-      id: nether2
-      run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.16.3
-      if: steps.nether2.outputs.sucess != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.2 --compile craftbukkit
 
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -85,13 +85,13 @@ jobs:
       id: nether
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.1-R0.1-SNAPSHOT/craftbukkit-1.16.1-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.16.1
-      if: steps.nether.outputs.sucess != 'true''
+      if: steps.nether.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.1 --compile craftbukkit
     - name: Test 1.16.3
       id: nether2
       run: test -f ~/.m2/repository/org/bukkit/craftbukkit/1.16.3-R0.1-SNAPSHOT/craftbukkit-1.16.3-R0.1-SNAPSHOT.jar && echo "::set-output name=sucess::true"
     - name: 1.16.3
-      if: steps.nether2.outputs.sucess != 'true''
+      if: steps.nether2.outputs.sucess != 'true'
       run: cd BuildTools && java -jar BuildTools.jar --rev 1.16.2 --compile craftbukkit
 
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,7 @@ jobs:
 #    - name: [version]
 #      if: steps.frostburn.outputs.sucess != 'true'
 #      run: cd BuildTools && java -jar BuildTools.jar --rev [version] <if newer than 1.14:  --compile craftbukkit>
-    - run: ls ~/.m2/repository/org/bukkit/craftbukkit/
+    - run: test -d ~/.m2/repository/org/bukkit/craftbukkit/ && ls ~/.m2/repository/org/bukkit/craftbukkit/
 
     - name: Test 1.8.8
       id: bountiful

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Movecraft
-[![Java CI]](https://github.com/eirik1996/Movecraft/workflows/Java%20CI/badge.svg?branch=master)
+![Java CI](https://github.com/eirik1996/Movecraft/workflows/Java%20CI/badge.svg?branch=master)
 [![codebeat badge](https://codebeat.co/badges/77751ae4-80f7-460a-a225-0e3ae8cbbab1)](https://codebeat.co/projects/github-com-apdevteam-movecraft-master)
 [![Build Status](https://travis-ci.org/APDevTeam/Movecraft.svg?branch=master)](https://travis-ci.org/APDevTeam/Movecraft)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Movecraft
-![Java CI](https://github.com/eirik1996/Movecraft/workflows/Java%20CI/badge.svg?branch=master)
+![Java CI](https://github.com/eirikh1996/Movecraft/workflows/Java%20CI/badge.svg?branch=master)
 [![codebeat badge](https://codebeat.co/badges/77751ae4-80f7-460a-a225-0e3ae8cbbab1)](https://codebeat.co/projects/github-com-apdevteam-movecraft-master)
 [![Build Status](https://travis-ci.org/APDevTeam/Movecraft.svg?branch=master)](https://travis-ci.org/APDevTeam/Movecraft)
 

--- a/modules/Movecraft/pom.xml
+++ b/modules/Movecraft/pom.xml
@@ -9,13 +9,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-<<<<<<< HEAD
-    <!--<version>7.0.0_beta_5</version>-->
-    <version>7.0.0_for_1.8.8-1.16.2_beta_33</version>
-=======
-    <version>7.0.0_beta_6</version>
 
->>>>>>> d85e113d2393a27b85a04cbe7b54210a7bab78e9
+    <!--<version>7.0.0_beta_6</version>-->
+    <version>7.0.0_for_1.8.8-1.16.2_beta_33</version>
+         
     <repositories>
         <repository>
             <id>spigot-repo</id>


### PR DESCRIPTION
### Describe in detail what your pull request acomplishes
This PR improves CI performance by only building craftbukkit when the cache is cleared rather than on each version (or pom) change.

In addition, it fixes the merge conflicts in the main POM and the CI badge in the readme.