### PR TITLE
Fix several signs not resetting upon a craft being piloted

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/AscendSign.java
@@ -24,7 +24,7 @@ public class AscendSign implements Listener {
         for(MovecraftLocation location: event.getCraft().getHitBox()){
             Block block = location.toBukkit(world).getBlock();
             if(!SignUtils.isSign(block)){
-                return;
+                continue;
             }
             Sign sign = (Sign) block.getState();
             if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Ascend: ON")) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/CruiseSign.java
@@ -30,7 +30,7 @@ public final class CruiseSign implements Listener{
         for(MovecraftLocation location: event.getCraft().getHitBox()){
             Block block = location.toBukkit(world).getBlock();
             if(!SignUtils.isSign(block)){
-                return;
+                continue;
             }
             Sign sign = (Sign) block.getState();
             if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Cruise: ON")) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/DescendSign.java
@@ -24,7 +24,7 @@ public final class DescendSign implements Listener{
         for(MovecraftLocation location: event.getCraft().getHitBox()){
             Block block = location.toBukkit(world).getBlock();
             if(!SignUtils.isSign(block)){
-                return;
+                continue;
             }
             Sign sign = (Sign) block.getState();
             if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Descend: ON")) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SpeedSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/SpeedSign.java
@@ -19,7 +19,7 @@ public final class SpeedSign implements Listener{
         for(MovecraftLocation location: event.getCraft().getHitBox()){
             Block block = location.toBukkit(world).getBlock();
             if(!SignUtils.isSign(block)) {
-                return;
+                continue;
             }
             Sign sign = (Sign) block.getState();
             if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Speed:")) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
@@ -30,7 +30,7 @@ public final class StatusSign implements Listener{
         for(MovecraftLocation location: event.getCraft().getHitBox()){
             Block block = location.toBukkit(world).getBlock();
             if(!SignUtils.isSign(block)){
-                return;
+                continue;
             }
             Sign sign = (Sign) block.getState();
             if (ChatColor.stripColor(sign.getLine(0)).equalsIgnoreCase("Status:")) {


### PR DESCRIPTION
<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request accomplishes

Ascend, Cruise, Descend, Speed and Status signs are supposed to be reset when their ship is piloted. However, this was broken as the loop that checks for them within a ship's hitbox would terminate upon encountering a single non-sign block. This is fixed by replacing the `return` that causes this with a `continue`, so the hitbox is fully checked.


### Checklist
- [x] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [x] Proper internationalization
- [x] Compiled/tested
