### PR TITLE
Fix issue of redstone blocks spawning under ships

### DIFF
--- a/modules/v1_18_R1/src/main/java/net/countercraft/movecraft/compat/v1_18_R1/IWorldHandler.java
+++ b/modules/v1_18_R1/src/main/java/net/countercraft/movecraft/compat/v1_18_R1/IWorldHandler.java
@@ -154,7 +154,7 @@ public class IWorldHandler extends WorldHandler {
             final BlockPos position = entry.getKey();
             final BlockState data = entry.getValue();
             LevelChunk chunk = nativeWorld.getChunkAt(position);
-            LevelChunkSection chunkSection = chunk.getSections()[position.getY()>>4];
+            LevelChunkSection chunkSection = chunk.getSections()[chunk.getSectionIndex(position.getY())];
             if (chunkSection == null) {
                 // Put a GLASS block to initialize the section. It will be replaced next with the real block.
                 chunk.setBlockState(position, Blocks.GLASS.defaultBlockState(), false);
@@ -301,7 +301,7 @@ public class IWorldHandler extends WorldHandler {
             final BlockPos position = entry.getKey();
             final BlockState data = entry.getValue();
             LevelChunk chunk = world.getChunkAt(position);
-            LevelChunkSection chunkSection = chunk.getSections()[position.getY()>>4];
+            LevelChunkSection chunkSection = chunk.getSections()[chunk.getSectionIndex(position.getY())];
             if (chunkSection == null) {
                 // Put a GLASS block to initialize the section. It will be replaced next with the real block.
                 chunk.setBlockState(position, Blocks.GLASS.defaultBlockState(), false);


### PR DESCRIPTION
### Describe in detail what your pull request acomplishes
Make IWorldHandler for 1.18 properly use chunk.getSectionIndex where needed

### Related issues: fixes #127 
- 

### Checklist
- [x] Compiled/tested
